### PR TITLE
edit graphgist with images not working

### DIFF
--- a/api/src/graphgists/mutations.js
+++ b/api/src/graphgists/mutations.js
@@ -319,7 +319,7 @@ export const UpdateGraphGist = async (root, args, context, info) => {
     for (const match of imagesMatches){
       const originalUrl =  match[1]
       const id = String(uuidv4())
-      const {...imageData} = await uploadImage(originalUrl, id) //Upload image to imagekit
+      const {versionInfo: _, ...imageData} = await uploadImage(originalUrl, id) //Upload image to imagekit
       asciidoc = asciidoc.replace(originalUrl, imageData.url)
 
       imageData.uuid = id;


### PR DESCRIPTION
failing with:
Property values can only be of primitive types or arrays thereof. Encountered: Map{name -> String('Version 1'), id -> String('62e168321b45f065d46baba3')}.